### PR TITLE
Add attribute getter for glfs object file type

### DIFF
--- a/src/pyglfs.h
+++ b/src/pyglfs.h
@@ -45,7 +45,7 @@ typedef struct {
 typedef struct {
 	PyObject_HEAD
 	py_glfs_t *py_fs;
-	PyObject *py_st;
+	struct stat st;
 	char uuid_str[37];
 	glfs_object_t *gl_obj;
 } py_glfs_obj_t;


### PR DESCRIPTION
Since struct stat is already cached in the python object, this is pretty low-cost to provide. Also add tp_repr function to display uuid and file type of glfs objects as a convenience feature.