### PR TITLE
Add "name" attribute to GLFS object handles

### DIFF
--- a/src/pyglfs-volume.c
+++ b/src/pyglfs-volume.c
@@ -586,7 +586,7 @@ static PyObject *py_glfs_get_root(PyObject *obj,
 		return NULL;
 	}
 
-	return init_glfs_object(self, gl_obj, &st);
+	return init_glfs_object(self, gl_obj, &st, "/");
 }
 
 static PyObject *py_glfs_volume_repr(PyObject *obj)
@@ -678,7 +678,7 @@ static PyObject *py_glfs_open_by_uuid(PyObject *obj,
 		return NULL;
 	}
 
-	return init_glfs_object(self, gl_obj, &st);
+	return init_glfs_object(self, gl_obj, &st, NULL);
 }
 
 static PyMethodDef py_glfs_volume_methods[] = {

--- a/src/pyglfs.h
+++ b/src/pyglfs.h
@@ -44,6 +44,7 @@ typedef struct {
 
 typedef struct {
 	PyObject_HEAD
+	PyObject *name;
 	py_glfs_t *py_fs;
 	struct stat st;
 	char uuid_str[37];
@@ -69,6 +70,6 @@ extern bool init_pystat_type(void);
 extern PyObject *stat_to_pystat(struct stat *st);
 
 extern bool init_glfd(void);
-extern PyObject *init_glfs_object(py_glfs_t *py_fs, glfs_object_t *gl_obj, struct stat *pst);
+extern PyObject *init_glfs_object(py_glfs_t *, glfs_object_t *, const struct stat *, const char *);
 extern PyObject *init_glfs_fd(glfs_fd_t *fd_in, py_glfs_obj_t *hdl, int flags);
 #endif


### PR DESCRIPTION
This is convenience feature to show path by which handle was opened. This name will also be part of tp_repr for the object which should help with debugging issues in the bindings. In case object handle is opened by UUID, the name will be None via attribute and "<UNKNOWN>" via repr.