### PR TITLE
NAS-118969 / Fix fchmod on directories

### DIFF
--- a/src/pyglfs-fd.c
+++ b/src/pyglfs-fd.c
@@ -44,8 +44,14 @@ static int py_glfs_fd_init(PyObject *obj,
 void py_glfs_fd_dealloc(py_glfs_fd_t *self)
 {
 	if (self->fd) {
-		if (glfs_close(self->fd) == -1) {
-			fprintf(stderr, "glfs_close() failed: %s",
+		int rv;
+		if (self->flags & O_DIRECTORY) {
+			rv = glfs_closedir(self->fd);
+		} else {
+			rv = glfs_close(self->fd);
+		}
+		if (rv == -1) {
+			fprintf(stderr, "glusterfs fd close failed: %s\n",
 				strerror(errno));
 		}
 		self->fd = NULL;

--- a/src/pyglfs-handle.c
+++ b/src/pyglfs-handle.c
@@ -386,7 +386,11 @@ static PyObject *py_glfs_obj_open(PyObject *obj,
 	}
 
 	Py_BEGIN_ALLOW_THREADS
-	gl_fd = glfs_h_open(self->py_fs->fs, self->gl_obj, flags);
+	if (flags & O_DIRECTORY) {
+		gl_fd = glfs_h_opendir(self->py_fs->fs, self->gl_obj);
+	} else {
+		gl_fd = glfs_h_open(self->py_fs->fs, self->gl_obj, flags);
+	}
 	Py_END_ALLOW_THREADS
 
 	if (gl_fd == NULL) {


### PR DESCRIPTION
libgfapi will silently fail fchmod() ops on
glusterfs fds on directories if they are opened
via glfs_open() rather than glfs_opendir(). So
for now, always open directories via glfs_opendir().